### PR TITLE
Update SpoutSDK.cpp

### DIFF
--- a/libs/src/SpoutSDK.cpp
+++ b/libs/src/SpoutSDK.cpp
@@ -72,7 +72,7 @@ Spout::Spout()
 	
 	// Debug console window so printf works
 	FILE* pCout; // should really be freed on exit 
-	AllocConsole();
+	//AllocConsole();
 	freopen_s(&pCout, "CONOUT$", "w", stdout); 
 	printf("Spout::Spout()\n");
 	


### PR DESCRIPTION
Hello,

I commented AllocConsole() because it was overriding my VIsual settings studio deciding if there should be a console or not when generating an application.

I guess the IDE (Visual for example) should decide when spawning a console or not.

The phylosophy I'm using in my own code is telling visual to spawn a console when in debug mode and not in release mode.

Please tell me if there are other reasons.

Cheers,

Dav'
