### PR TITLE
Better handling of empty or resizing textures

### DIFF
--- a/src/ofxSpout2Sender.cpp
+++ b/src/ofxSpout2Sender.cpp
@@ -9,6 +9,11 @@ Sender::Sender() {
 //--------------------------------------------------------------
 void Sender::sendTexture(ofTexture& t, string name)
 {
+    if (!t.isAllocated()) {
+        ofLogNotice("ofxSpout2Sender", "texture to send it not allocated for sender name %s.", name.c_str());
+        return;
+    }
+
 	int width = t.getWidth();
 	int height = t.getHeight();
 

--- a/src/ofxSpout2Sender.cpp
+++ b/src/ofxSpout2Sender.cpp
@@ -21,41 +21,63 @@ void Sender::sendTexture(ofTexture& t, string name)
 	int i = ofFind(senderNameList, name); 
 
 	//if the sender is not there
-	if (i == senderNameList.size()) {
-		char senderNameChars[256];
-		strcpy_s(senderNameChars, name.c_str());
-		SpoutSender* sender = new SpoutSender();
-		bool init = sender->CreateSender(senderNameChars, width, height);
-	
-		if (init) {
-			ofLogNotice("ofxSpout2 Sender created");
-			//init the fbo
-			ofFbo senderFbo;
-			ofFbo::Settings s;
-			s.width = width;
-			s.height = height;
-			s.internalformat = GL_RGBA;
-			s.textureTarget = GL_TEXTURE_2D;
-			s.useDepth = false;
-			s.useStencil = false;
-			s.minFilter = GL_LINEAR;
-			s.maxFilter = GL_LINEAR;
-			s.wrapModeHorizontal = GL_CLAMP_TO_EDGE;
-			s.wrapModeVertical = GL_CLAMP_TO_EDGE;
-			s.numSamples = 0;
-			senderFbo.allocate(s);
-			senderFboList.push_back(senderFbo);
-			senderWidthList.push_back(width);
-			senderHeightList.push_back(height);
-			senderNameList.push_back(name);
-			spoutSenderList.push_back(sender);
-		} else {
-			ofLogError("ofxSpout2 Sender creation failed");
-		}
-		//we cannot create sender and immediatly send texture; so return
-		return;
-	}
+    bool buildFBO = false;
+    bool appendFBO = false;
+    if (i == senderNameList.size()) {
+        char senderNameChars[256];
+        strcpy_s(senderNameChars, name.c_str());
+        SpoutSender* sender = new SpoutSender();
+        bool init = sender->CreateSender(senderNameChars, width, height);
+        if (init) {
+            buildFBO = true;
+            spoutSenderList.push_back(sender);
+        }
+        else {
+            ofLogError("ofxSpout2 Sender creation failed");
+        }
+    }
+    else if (width != senderWidthList[i] || height != senderHeightList[i]) {
+        ofLogNotice("ofxSpout2", "Texture size changed. Updating sender.");
+        char senderNameChars[256];
+        strcpy_s(senderNameChars, name.c_str());
+        spoutSenderList[i]->UpdateSender(senderNameChars, width, height); //  ReleaseSender();
+        buildFBO = true;
+    }
 
+    if (buildFBO) {
+        //init the fbo
+        ofFbo senderFbo;
+        ofFbo::Settings s;
+        s.width = width;
+        s.height = height;
+        s.internalformat = GL_RGBA;
+        s.textureTarget = GL_TEXTURE_2D;
+        s.useDepth = false;
+        s.useStencil = false;
+        s.minFilter = GL_LINEAR;
+        s.maxFilter = GL_LINEAR;
+        s.wrapModeHorizontal = GL_CLAMP_TO_EDGE;
+        s.wrapModeVertical = GL_CLAMP_TO_EDGE;
+        s.numSamples = 0;
+        senderFbo.allocate(s);
+
+        if (i >= senderNameList.size()) {
+            // TODO: not very elegant. merge these things into a struct pack things into a map<Name,SenderDataStruct>
+            senderFboList.push_back(senderFbo);
+            senderWidthList.push_back(width);
+            senderHeightList.push_back(height);
+            senderNameList.push_back(name);
+
+            //we cannot create sender and immediatly send texture; so return
+            return;
+        }
+        else {
+            senderFboList[i] = senderFbo;
+            senderWidthList[i] = width;
+            senderHeightList[i] = height;
+            senderNameList[i] = name;
+        }
+    }
 
 	if (i >= 0 && i < senderNameList.size())
 	{		


### PR DESCRIPTION
This is basically a fix for #7. Also, there was a crash when initially sending an unallocated texture.